### PR TITLE
Add heroku-24 platform

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -25,18 +25,29 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
-      - name: Build and push cedar-14
-        uses: docker/build-push-action@v2
-        with:
-          push: true
-          file: Dockerfile.cedar-14
-          tags: |
-            openaustralia/buildstep:cedar-14
+      # 2025-05-21 Right now all I want to do is test the new heroku-24. I'm disabling the older builds so the
+      # existing working images don't get disturbed.
 
-      - name: Build and push heroku-18
+      # - name: Build and push cedar-14
+      #   uses: docker/build-push-action@v2
+      #   with:
+      #     push: true
+      #     file: Dockerfile.cedar-14
+      #     tags: |
+      #       openaustralia/buildstep:cedar-14
+
+      # - name: Build and push heroku-18
+      #   uses: docker/build-push-action@v2
+      #   with:
+      #     push: true
+      #     file: Dockerfile.heroku-18
+      #     tags: |
+      #       openaustralia/buildstep:heroku-18
+      
+      - name: Build and push heroku-24
         uses: docker/build-push-action@v2
         with:
           push: true
-          file: Dockerfile.heroku-18
+          file: Dockerfile.heroku-24
           tags: |
-            openaustralia/buildstep:heroku-18
+            openaustralia/buildstep:heroku-24

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -50,4 +50,4 @@ jobs:
           push: true
           file: Dockerfile.heroku-24
           tags: |
-            openaustralia/buildstep:heroku-24
+            ${{ github.repository }}:heroku-24

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "makefile.configureOnOpen": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "makefile.configureOnOpen": false
-}

--- a/Dockerfile.heroku-24
+++ b/Dockerfile.heroku-24
@@ -19,18 +19,16 @@ ADD prerun.rb /usr/local/lib/prerun.rb
 RUN apt-get update && apt-get install -y time libblas-dev liblapack-dev gfortran swig protobuf-compiler libprotobuf-dev libsqlite3-dev poppler-utils libffi-dev
 
 # PhantomJS has been deprecated
-RUN apt-get install -y phantomjs
+# RUN apt-get install -y phantomjs
 
 # Version of chromedriver needs to match up with the version of chrome installed
-# As of June 27 2022, Google Chrome version 103.0.5060.53 is installed
-# There doesn't seem to a way that I can see to force a particular (old) version of
-# Chrome to be installed. Sigh.
+# As of May 21 2025, Google Chrome version 136.0.7103.113-1 is installed
 
 # Install chromedriver
-RUN wget https://chromedriver.storage.googleapis.com/103.0.5060.53/chromedriver_linux64.zip && \
-			unzip chromedriver_linux64.zip && \
-			rm chromedriver_linux64.zip && \
-			mv chromedriver /usr/local/bin && \
+RUN wget https://storage.googleapis.com/chrome-for-testing-public/136.0.7103.94/linux64/chromedriver-linux64.zip && \
+			unzip chromedriver-linux64.zip && \
+			rm chromedriver-linux64.zip && \
+			mv chromedriver-linux64/chromedriver /usr/local/bin && \
 			chmod ugo+x /usr/local/bin/chromedriver
 
 # Install chrome

--- a/Dockerfile.heroku-24
+++ b/Dockerfile.heroku-24
@@ -1,0 +1,52 @@
+FROM gliderlabs/herokuish:v0.10.3-24
+
+# Add perl buildpack for morph
+RUN /bin/herokuish buildpack install https://github.com/miyagawa/heroku-buildpack-perl.git 1f7fafa95a00ee39df9d5a035c6a253d1d79fe56
+
+# Add certificate authority used by mitmproxy
+# Also needs to be identical to the cert at mitmproxy/mitmproxy-ca-cert.pem in
+# https://github.com/openaustralia/morph
+ADD mitmproxy-ca-cert.pem /usr/local/share/ca-certificates/mitmproxy-ca-cert.crt
+RUN update-ca-certificates
+
+# Add prerun script which will disable output buffering for ruby
+ADD prerun.rb /usr/local/lib/prerun.rb
+
+# poppler-utils has a more recent pdftohtml than the pdftohtml package
+# pdftohtml is needed by the python scraperwiki library
+# libffi-dev needed by python cffi
+# time is needed directly by morph.io for scraper run measurements
+RUN apt-get update && apt-get install -y time libblas-dev liblapack-dev gfortran swig protobuf-compiler libprotobuf-dev libsqlite3-dev poppler-utils libffi-dev
+
+# PhantomJS has been deprecated
+RUN apt-get install -y phantomjs
+
+# Version of chromedriver needs to match up with the version of chrome installed
+# As of June 27 2022, Google Chrome version 103.0.5060.53 is installed
+# There doesn't seem to a way that I can see to force a particular (old) version of
+# Chrome to be installed. Sigh.
+
+# Install chromedriver
+RUN wget https://chromedriver.storage.googleapis.com/103.0.5060.53/chromedriver_linux64.zip && \
+			unzip chromedriver_linux64.zip && \
+			rm chromedriver_linux64.zip && \
+			mv chromedriver /usr/local/bin && \
+			chmod ugo+x /usr/local/bin/chromedriver
+
+# Install chrome
+RUN curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+			echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list && \
+			apt-get update && \
+			apt-get -y install google-chrome-stable
+
+# We also need to make chrome trust our CA cert
+RUN apt-get -y install libnss3-tools && \
+			mkdir -p /app/.pki/nssdb && \
+			certutil -d sql:/app/.pki/nssdb -N --empty-password && \
+			certutil -d sql:/app/.pki/nssdb -A -t "C,," -n "mitmproxy ca cert" -i /usr/local/share/ca-certificates/mitmproxy-ca-cert.crt
+
+# Make python pip use the new ca certificate. Wouldn't it be great if it used
+# the system ca certificates by default? Well, it doesn't.
+# Setting the PIP_CERT environment variable didn't work but this does
+# TODO Remove this once compiles don't send traffic to mitmproxy
+ADD pip.conf /etc/pip.conf

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,17 @@
 
 all: build
 
-build:
+heroku-24: Dockerfile.heroku-24
+	docker build -t openaustralia/buildstep:heroku-24 -f Dockerfile.heroku-24 .
+
+cedar-14: Dockerfile.cedar-14
 	docker build -t openaustralia/buildstep:cedar-14 -f Dockerfile.cedar-14 .
+
+heroku-18: Dockerfile.heroku-18
 	docker build -t openaustralia/buildstep:heroku-18 -f Dockerfile.heroku-18 .
-	docker build -t openaustralia/buildstep:heroku-24 -f Dockerfile.heroku-24
+
+build-obsolete: heroku-18 cedar-14
+
+build: heroku-24
+
+	

--- a/Makefile
+++ b/Makefile
@@ -4,3 +4,4 @@ all: build
 build:
 	docker build -t openaustralia/buildstep:cedar-14 -f Dockerfile.cedar-14 .
 	docker build -t openaustralia/buildstep:heroku-18 -f Dockerfile.heroku-18 .
+	docker build -t openaustralia/buildstep:heroku-24 -f Dockerfile.heroku-24


### PR DESCRIPTION
Resolves 
* https://github.com/planningalerts-scrapers/issues/issues/1073

Relates to:
* https://github.com/openaustralia/morph/issues/1440

Image available for testing from https://hub.docker.com/repository/docker/tchaypo/buildstep/general

I've been able to confirm that this builds, and runs scrapers on my local machine. I'm not certain if it will work in the Morph context as I'm not sure how the mitmproxy setup there is working now.

I think this should be safe to merge though.

- I've changed the Action to make sure it won't interfere with the existing `cedar-14` and `buildstep-18` images
- Only scrapers that explicitly request the `heroku-24` platform will run on it; existing scrapers will still use their existing working platform.

Last time we added a platform to Morph we blogged about it - https://www.oaf.org.au/2019/04/10/a-new-era-for-morph-io/. That post might be a template for a new post letting people know about the new platform.

I *think* that the work I did to add multi-platform to Morph should mean that as soon as the new docker image is available people can use it, without any code changes being needed on Morph.

I have commented out the actions that rebuild cedar-14 and heroku-18 images because of
- untested assumptions about those not being buildable any more, but also
- because scrapers that use those platforms are working, so I don't want to update the images

I've got two main things I'd like to get checked before I make this available (for testing, soft launch only) on morph:
- mitmproxy certificates - the ones in the repo seem to be old - I have a feeling there's something I need to do to put newer ones into the images
- Removing phantomjs - I'm assuming that, at worst, this will break some old scrapers that might have used that - but if we find any of those, they can carry on using `cedar-14` or `heroku-18`, at least until those platforms break from old mitmproxy certificates
