### PR TITLE
Add ENV variable to force sequential DNS queries in Dockerfile.heroku-24

### DIFF
--- a/Dockerfile.heroku-24
+++ b/Dockerfile.heroku-24
@@ -1,5 +1,10 @@
 FROM gliderlabs/herokuish:v0.10.3-24
 
+# Docker 20.10.7's default seccomp profile blocks clone3, which glibc 2.34+
+# (Ubuntu 22.04+) requires for parallel A/AAAA DNS queries. Force sequential
+# queries to avoid thread creation during name resolution.
+ENV RES_OPTIONS="single-request"
+
 # Add perl buildpack for morph
 RUN /bin/herokuish buildpack install https://github.com/miyagawa/heroku-buildpack-perl.git 1f7fafa95a00ee39df9d5a035c6a253d1d79fe56
 


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?
Adds an environment variable to the Dockerfile to enforce sequential DNS queries.

## Why was this needed?
We run Docker 20.10.7 on Morph.io which creates issues with newer versions of Ubuntu (which buildstep is based on).

This change addresses issues with parallel DNS queries that can occur due to Docker's default seccomp profile, which affects certain versions of glibc.

## Implementation/Deploy Steps (Optional)
CI/CD should deploy this to docker. We will then need to force an update on the docker image on the Morph server and test that morph scrapers work as expected on heroku-24 

## Notes to reviewer (Optional)
I have not been able to test this locally as I use an ARM Mac, which doesn't support installing Chrome this way. Please ensure you have tested this locally before deploying to production.