### PR TITLE
Build only action

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,0 +1,54 @@
+name: build-and-push
+on:
+  push:
+    branches: 
+      - 'main'
+    
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      # https://github.com/docker/setup-qemu-action
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker Registry
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      # 2025-05-21 Right now all I want to do is test the new heroku-24. I'm disabling the older builds so the
+      # existing working images don't get disturbed.
+
+      # - name: Build and push cedar-14
+      #   uses: docker/build-push-action@v2
+      #   with:
+      #     push: true
+      #     file: Dockerfile.cedar-14
+      #     tags: |
+      #       openaustralia/buildstep:cedar-14
+
+      # - name: Build and push heroku-18
+      #   uses: docker/build-push-action@v2
+      #   with:
+      #     push: true
+      #     file: Dockerfile.heroku-18
+      #     tags: |
+      #       openaustralia/buildstep:heroku-18
+      
+      - name: Build and push heroku-24
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          file: Dockerfile.heroku-24
+          tags: |
+            ${{ github.repository }}:heroku-24

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -2,7 +2,8 @@ name: build-docker-images
 
 on:
   push:
-    branches: master
+    branches: 
+      - 'main'
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,14 @@
-name: build-docker-images
-
+name: build
 on:
+  workflow_dispatch:
   push:
-    branches: 
+    branches:
       - 'main'
+    tags:
+      - 'heroku-24'
+  pull_request:
+    branches:
+      - 'main'   
 
 jobs:
   build:
@@ -12,6 +17,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/openaustralia/buildstep
+        
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -20,11 +31,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Login to Docker Registry
-        uses: docker/login-action@v1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       # 2025-05-21 Right now all I want to do is test the new heroku-24. I'm disabling the older builds so the
       # existing working images don't get disturbed.
@@ -45,10 +57,10 @@ jobs:
       #     tags: |
       #       openaustralia/buildstep:heroku-18
       
-      - name: Build and push heroku-24
-        uses: docker/build-push-action@v2
+      - name: Build and push
+        uses: docker/build-push-action@v7
         with:
           push: true
           file: Dockerfile.heroku-24
-          tags: |
-            ${{ github.repository }}:heroku-24
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Relevant issue(s)
None

## What does this do?
Adds a second Action that can be triggered manually, and will fire on pull requests.

This pushes images only to the local ghcr repo - so they can be examined and tested without updating the docker images that morph uses

Rather than hand-specifying tags, labels etc I'm using https://github.com/docker/metadata-action to extract labels automatically. 

## Why was this needed?
To allow for resting of changes 

## Implementation/Deploy Steps (Optional)
If I've understood the action of the metadata-action - once this is ready, we can make a branch named "heroku-24". Once we add configs to the action to make it trigger on pushes to that branch, they'll automatically get the "heroku-24" tag.

## Notes to reviewer (Optional)
This repo's packages are currently set to private. I'd like to change this to public, to allow anonymous downloads, but that's prohibited at the organisation level. I don't know why - might change that, will discuss with Ben.

In the meantime, if you want to use the images, you'll need to [create a classic personal access token with read packages permission](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic), then use it to "docker login ghcr.io" - use your github username, and the PAT as the password.


